### PR TITLE
provide right link for Accessibility course

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Powered by Snapp! Front-End Engineers 💚
 
 ### Deep & Advanced
 
-- **[Accessibility](https://frontendmasters.com/courses/archive/web-accessibility)**<br>
+- **[Accessibility](https://frontendmasters.com/courses/accessibility-v2/)**<br>
   🙍🏻‍♂️ _Instructor: Jon Kuperman_ <br>
   ⏰ _4 Hours_ <br>
   📝 _Website Accessibility_


### PR DESCRIPTION
The link for accessibility course go 404 and I provide right link for it here is the [link](https://frontendmasters.com/courses/accessibility-v2/)